### PR TITLE
fix install editable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "weave",
 ]
 
+[tool.setuptools]
+packages = ["programmer"]
+
 [project.urls]
 Homepage = "https://github.com/wandb/programmer"
 


### PR DESCRIPTION
Fixed this error when installing from source:
```bash
error: Failed to download distributions
  Caused by: Failed to fetch wheel: programmer @ file:///Users/tcapelle/work/programmer
  Caused by: Failed to build: `programmer @ file:///Users/tcapelle/work/programmer`
  Caused by: Build backend failed to determine extra requires with `build_editable()` with exit status: 1
--- stdout:

--- stderr:
error: Multiple top-level packages discovered in a flat-layout: ['assets', 'programmer'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
```